### PR TITLE
Fix incorrect `ip` argument in app.run()

### DIFF
--- a/Flask-Example/main.py
+++ b/Flask-Example/main.py
@@ -9,4 +9,4 @@ def hello_world():
 
 
 if __name__ == '__main__':
-    app.run(debug=False, ip="0.0.0.0", port=5000)
+    app.run(debug=False, host="0.0.0.0", port=5000)


### PR DESCRIPTION
Replaced `ip="0.0.0.0"` with `host="0.0.0.0"` in `main.py` to fix a TypeError during Flask startup.

This change ensures compatibility with Flask's app.run() parameters and allows the app to bind to all interfaces as expected in production environments like Dokploy.

```
Traceback (most recent call last):
File "/app/main.py", line 12, in <module>
app.run(debug=False, ip="0.0.0.0", port=5000)
File "/opt/venv/lib/python3.12/site-packages/flask/app.py", line 625, in run
* Serving Flask app 'main'
* Debug mode: off
run_simple(t.cast(str, host), port, self, **options)
TypeError: run_simple() got an unexpected keyword argument 'ip'
```

This pull request includes a small change to the `Flask-Example/main.py` file. The change corrects the parameter name from `ip` to `host` in the `app.run` method, ensuring compatibility with Flask's expected arguments.